### PR TITLE
Output

### DIFF
--- a/thoth/app/arguments.py
+++ b/thoth/app/arguments.py
@@ -28,6 +28,11 @@ def parse_args() -> argparse.Namespace:
     )
 
     root_parser.add_argument(
+        "-o",
+        "--output",
+        help="Output the result of the disassembler/decompiler to a file",
+    )
+    root_parser.add_argument(
         "-call",
         "--call",
         action="store_true",

--- a/thoth/app/arguments.py
+++ b/thoth/app/arguments.py
@@ -30,6 +30,8 @@ def parse_args() -> argparse.Namespace:
     root_parser.add_argument(
         "-o",
         "--output",
+        action="store",
+        type=argparse.FileType("w"),
         help="Output the result of the disassembler/decompiler to a file",
     )
     root_parser.add_argument(

--- a/thoth/app/decompiler/decompiler.py
+++ b/thoth/app/decompiler/decompiler.py
@@ -70,7 +70,10 @@ class Decompiler:
             variables_names = [variable.name for variable in self.get_phi_node_variables()]
             # Phi function is represented in the form Φ(var1, var2, ..., var<n>)
             phi_node_representation = "Φ(%s)" % ", ".join(variables_names)
-        elif self.block_new_variables == 0 and len(self.current_function.cfg.parents(self.current_basic_block)) != 0:
+        elif (
+            self.block_new_variables == 0
+            and len(self.current_function.cfg.parents(self.current_basic_block)) != 0
+        ):
             phi_node_variables = self.get_phi_node_variables()
             if len(phi_node_variables) != 0:
                 phi_node_representation = phi_node_variables[-1].name
@@ -165,10 +168,13 @@ class Decompiler:
 
                 if self.ssa.get_variable(op0_register, offset_1)[2] in phi_node_variables:
                     operand = phi_node_representation
-                elif self.block_new_variables == 0 and len(self.current_function.cfg.parents(self.current_basic_block)) != 0:
+                elif (
+                    self.block_new_variables == 0
+                    and len(self.current_function.cfg.parents(self.current_basic_block)) != 0
+                ):
                     if len(phi_node_variables) != 0:
                         operand = phi_node_representation
-                    else: 
+                    else:
                         operand = self.ssa.get_variable(op0_register, offset_1)[1]
                 else:
                     operand = self.ssa.get_variable(op0_register, offset_1)[1]

--- a/thoth/app/disassembler/disassembler.py
+++ b/thoth/app/disassembler/disassembler.py
@@ -134,7 +134,7 @@ class Disassembler:
         self,
         function_name: Optional[str] = None,
         function_offset: Optional[str] = None,
-    ) -> None:
+    ) -> str:
         """Print the disassembly of all the bytecodes or a given function.
 
         Args:
@@ -144,23 +144,36 @@ class Disassembler:
         Raises:
             SystemExit: If the function name or offset does not exist.
         """
+        disassembly_code = ""
+
         if self.builtins:
             print("_" * 75)
-            print(self.print_builtins())
+            builtins = self.print_builtins()
+            disassembly_code += "_" * 75 + "\n"
+            print(builtins)
+            disassembly_code += builtins + "\n"
         if self.structs:
             print("_" * 75)
-            print(self.print_structs())
+            disassembly_code += "_" * 75 + "\n"
+            structs = self.print_structs()
+            print(structs)
+            disassembly_code += structs + "\n"
         if self.events:
             print("_" * 75)
-            print(self.print_events())
+            disassembly_code += "_" * 75 + "\n"
+            events = self.print_events()
+            print(events)
+            disassembly_code += events + "\n"
         print("_" * 75)
+        disassembly_code += "_" * 75 + "\n"
 
         if self.functions == []:
             return
 
         elif function_name is None and function_offset is None:
             for function in self.functions:
-                function.print()
+                function_str = function.print()
+                disassembly_code += function_str + "\n"
 
         else:
             if function_name is not None:
@@ -169,9 +182,11 @@ class Disassembler:
                 function = self.get_function_by_offset(function_offset)
 
             if function is not None:
-                function.print()
+                function_str = function.print()
+                disassembly_code += function_str + "\n"
             else:
                 raise SystemExit("Error: Function does not exist.")
+        return disassembly_code
 
     def print_structs(self, decompiler: bool = False) -> str:
         """Print the structures parsed from the ABI.
@@ -349,7 +364,7 @@ class Disassembler:
         # print(json.dumps(analytics, indent=3))
         return analytics
 
-    def decompiler(self) -> None:
+    def decompiler(self) -> str:
         """
         Decompile the functions
         """
@@ -361,4 +376,6 @@ class Disassembler:
                 print(f"from {package} import {function_name}")
         print(self.print_structs(decompiler=True))
         decomp = Decompiler(functions=self.functions)
-        print(decomp.decompile_code())
+        decompiled_code = decomp.decompile_code()
+        print(decompiled_code)
+        return decompiled_code

--- a/thoth/app/disassembler/function.py
+++ b/thoth/app/disassembler/function.py
@@ -139,11 +139,16 @@ class Function:
         """
         Iterate over each instruction and print the disassembly
         """
+        function_str = ""
         prototype = self.get_prototype()
         print(f"\n\t{utils.color.BLUE + prototype + utils.color.ENDC}")
+        function_str += "\n\t%s\n" % prototype
         for instr in self.instructions:
-            print(instr.print(), end="")
+            instruction_str = instr.print()
+            print(instruction_str, end="")
+            function_str += instruction_str
         print()
+        return function_str
 
     def generate_cfg(self) -> None:
         """Generate the CFG"""

--- a/thoth/thoth.py
+++ b/thoth/thoth.py
@@ -39,14 +39,16 @@ def main() -> int:
     if args.verbose:
         disassembler.dump_json()
 
-    # print assembly code
+    # Decompiler
     if args.decompile:
         output = disassembler.decompiler()
+    # Disassembler
     elif args.disassembly:
         output = disassembler.print_disassembly()
-    if args.output:
-        with open(args.output, "w") as f:
-            f.write(output)
+    # Save output to file
+    if args.output and (args.decompile or args.disassembly):
+        with args.output as output_file:
+            output_file.write(output)
 
     format = "pdf" if args.format is None else str(args.format)
 

--- a/thoth/thoth.py
+++ b/thoth/thoth.py
@@ -41,9 +41,12 @@ def main() -> int:
 
     # print assembly code
     if args.decompile:
-        disassembler.decompiler()
+        output = disassembler.decompiler()
     elif args.disassembly:
-        disassembler.print_disassembly()
+        output = disassembler.print_disassembly()
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(output)
 
     format = "pdf" if args.format is None else str(args.format)
 


### PR DESCRIPTION
- Implement a `-o/--output` option in command line to output the result of the decompiler or disassembler into a file, e.g `thoth local tests/json_files/cairo_array_sum.json -d -o ./decompiler_output` will output the decompiler output to the `decompiler_output` file.