### PR TITLE
Fix typo in if/else statements

### DIFF
--- a/thoth/app/decompiler/decompiler.py
+++ b/thoth/app/decompiler/decompiler.py
@@ -317,7 +317,8 @@ class Decompiler:
             elif instruction.pcUpdate == "JUMP_REL":
                 if self.ifcount != 0:
                     self.tab_count -= 1
-                    source_code += self.print_instruction_decomp("else:", color=utils.color.RED)
+                    source_code += self.print_instruction_decomp("else", color=utils.color.RED)
+                    source_code += self.print_instruction_decomp(" {", color=utils.color.ENDC, tab_count=0)
                     self.tab_count += 1
                     self.end_else.append(
                         int(utils.field_element_repr(int(instruction.imm), instruction.prime))


### PR DESCRIPTION
Before:

```
if cond {
 return 1;
else :
   return 0;
}
```
After : 
```
if cond {
 return 1;
} else {
 return 0;
}
```