### PR TITLE
Improve the documentation of the symbolic execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,11 @@ thoth local tests/json_files/cairo_test_symbolic_execution.json -a assignations
 
 [+] 1 analyzer was run (1 detected)
 
+# Set variables with a custom value
+thoth local tests/json_files/cairo_test_symbolic_execution.json --symbolic -function __main__.test_symbolic_execution -variables v0_x=1 -constraint v4==0 v6==0 -solve v1_y
+
 # Solve the variables values with contraints 
+# You need to use the == operator to create a constraint
 thoth local tests/json_files/cairo_test_symbolic_execution.json --symbolic -function __main__.test_symbolic_execution -constraint v4==0 v6==0 -solve v0_x v1_y
 v0_x: 10
 v1_y: 15


### PR DESCRIPTION
This PR adds documentation for the `-variables` flag of the symbolic execution and details the usage of the `-constraint` flag.