### PR TITLE
Fix #107

### DIFF
--- a/tests/cairo_files/cairo_0/cairo_felt_sum.cairo
+++ b/tests/cairo_files/cairo_0/cairo_felt_sum.cairo
@@ -1,0 +1,12 @@
+%builtins output
+
+func sum2(x: felt, y: felt) -> felt {
+    return x + y;
+}
+
+func main{output_ptr: felt*}() {
+    let x = 1;
+    let y = 2;
+    let sum = sum2(x, y); 
+    return ();
+}

--- a/tests/json_files/cairo_0/cairo_felt_sum.json
+++ b/tests/json_files/cairo_0/cairo_felt_sum.json
@@ -1,0 +1,472 @@
+{
+    "attributes": [],
+    "builtins": [
+        "output"
+    ],
+    "compiler_version": "0.10.0",
+    "data": [
+        "0x482a7ffd7ffc8000",
+        "0x208b7fff7fff7ffe",
+        "0x480680017fff8000",
+        "0x1",
+        "0x480680017fff8000",
+        "0x2",
+        "0x1104800180018000",
+        "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffffb",
+        "0x480a7ffd7fff8000",
+        "0x208b7fff7fff7ffe"
+    ],
+    "debug_info": {
+        "file_contents": {},
+        "instruction_locations": {
+            "0": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.sum2"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.sum2.x": 0,
+                        "__main__.sum2.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 17,
+                    "end_line": 4,
+                    "input_file": {
+                        "filename": "tests/cairo_files/cairo_0/cairo_felt_sum.cairo"
+                    },
+                    "start_col": 12,
+                    "start_line": 4
+                }
+            },
+            "1": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.sum2"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.sum2.x": 0,
+                        "__main__.sum2.y": 1
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 18,
+                    "end_line": 4,
+                    "input_file": {
+                        "filename": "tests/cairo_files/cairo_0/cairo_felt_sum.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 4
+                }
+            },
+            "2": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 2,
+                        "__main__.main.x": 3,
+                        "__main__.main.y": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 14,
+                    "end_line": 8,
+                    "input_file": {
+                        "filename": "tests/cairo_files/cairo_0/cairo_felt_sum.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 21,
+                            "end_line": 10,
+                            "input_file": {
+                                "filename": "tests/cairo_files/cairo_0/cairo_felt_sum.cairo"
+                            },
+                            "start_col": 20,
+                            "start_line": 10
+                        },
+                        "While expanding the reference 'x' in:"
+                    ],
+                    "start_col": 13,
+                    "start_line": 8
+                }
+            },
+            "4": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 2,
+                        "__main__.main.x": 3,
+                        "__main__.main.y": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 14,
+                    "end_line": 9,
+                    "input_file": {
+                        "filename": "tests/cairo_files/cairo_0/cairo_felt_sum.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 24,
+                            "end_line": 10,
+                            "input_file": {
+                                "filename": "tests/cairo_files/cairo_0/cairo_felt_sum.cairo"
+                            },
+                            "start_col": 23,
+                            "start_line": 10
+                        },
+                        "While expanding the reference 'y' in:"
+                    ],
+                    "start_col": 13,
+                    "start_line": 9
+                }
+            },
+            "6": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 2,
+                        "__main__.main.x": 3,
+                        "__main__.main.y": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 25,
+                    "end_line": 10,
+                    "input_file": {
+                        "filename": "tests/cairo_files/cairo_0/cairo_felt_sum.cairo"
+                    },
+                    "start_col": 15,
+                    "start_line": 10
+                }
+            },
+            "8": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 2,
+                        "__main__.main.sum": 5,
+                        "__main__.main.x": 3,
+                        "__main__.main.y": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 28,
+                    "end_line": 7,
+                    "input_file": {
+                        "filename": "tests/cairo_files/cairo_0/cairo_felt_sum.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 28,
+                            "end_line": 7,
+                            "input_file": {
+                                "filename": "tests/cairo_files/cairo_0/cairo_felt_sum.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 15,
+                                    "end_line": 11,
+                                    "input_file": {
+                                        "filename": "tests/cairo_files/cairo_0/cairo_felt_sum.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 11
+                                },
+                                "While trying to retrieve the implicit argument 'output_ptr' in:"
+                            ],
+                            "start_col": 11,
+                            "start_line": 7
+                        },
+                        "While expanding the reference 'output_ptr' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 7
+                }
+            },
+            "9": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 6
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 2,
+                        "__main__.main.sum": 5,
+                        "__main__.main.x": 3,
+                        "__main__.main.y": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 15,
+                    "end_line": 11,
+                    "input_file": {
+                        "filename": "tests/cairo_files/cairo_0/cairo_felt_sum.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 11
+                }
+            }
+        }
+    },
+    "hints": {},
+    "identifiers": {
+        "__main__.main": {
+            "decorators": [],
+            "pc": 2,
+            "type": "function"
+        },
+        "__main__.main.Args": {
+            "full_name": "__main__.main.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.ImplicitArgs": {
+            "full_name": "__main__.main.ImplicitArgs",
+            "members": {
+                "output_ptr": {
+                    "cairo_type": "felt*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "__main__.main.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "__main__.main.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.main.output_ptr": {
+            "cairo_type": "felt*",
+            "full_name": "__main__.main.output_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 2,
+                    "value": "[cast(fp + (-3), felt**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.sum": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.sum",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 5
+                    },
+                    "pc": 8,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.x": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.x",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 2,
+                    "value": "cast(1, felt)"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.y": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 2,
+                    "value": "cast(2, felt)"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.sum2": {
+            "decorators": [],
+            "pc": 0,
+            "type": "function"
+        },
+        "__main__.sum2.Args": {
+            "full_name": "__main__.sum2.Args",
+            "members": {
+                "x": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "y": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "__main__.sum2.ImplicitArgs": {
+            "full_name": "__main__.sum2.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.sum2.Return": {
+            "cairo_type": "felt",
+            "type": "type_definition"
+        },
+        "__main__.sum2.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.sum2.x": {
+            "cairo_type": "felt",
+            "full_name": "__main__.sum2.x",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.sum2.y": {
+            "cairo_type": "felt",
+            "full_name": "__main__.sum2.y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        }
+    },
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+        "references": [
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 2,
+                "value": "[cast(fp + (-3), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 2,
+                "value": "cast(1, felt)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 2,
+                "value": "cast(2, felt)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 5
+                },
+                "pc": 8,
+                "value": "[cast(ap + (-1), felt*)]"
+            }
+        ]
+    }
+}

--- a/thoth/app/symbex/symbex.py
+++ b/thoth/app/symbex/symbex.py
@@ -85,7 +85,7 @@ class SymbolicExecution:
                     second_operand = int(operation[2].value)
                 else:
                     second_operand = [
-                        v for v in self.z3_variables if str(v) == operation[0].value[0]
+                        v for v in self.z3_variables if str(v) == operation[2].value[0]
                     ][0]
 
                 # Operation
@@ -233,6 +233,7 @@ class SymbolicExecution:
                     self.solver.add(variable_name == int(constraint[0][2]))
                 except:
                     continue
+
             # Solve the constraints
             if self.solver.check() == z3.sat:
                 model = self.solver.model()


### PR DESCRIPTION
This PR Fixes #107. 

For example this program:
```cairo
%builtins output

func sum2(x: felt, y: felt) -> felt {
    return x + y;
}

func main{output_ptr: felt*}() {
    let x = 1;
    let y = 2;
    let sum = sum2(x, y); 
    return ();
}
```

You can determine the values of x and y needed for the sum to be 10 with this command: 

```bash
thoth local tests/json_files/cairo_0/cairo_felt_sum.json --symbolic -function __main__.sum2 -constraint v4==10 -solve v0_x v1_y

v0_x: 10
v1_y: 0
```