### PR TITLE
Add inequalities and variables comparisons for the symbolic execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ thoth local tests/json_files/cairo_0/cairo_test_symbolic_execution.json --symbol
 v0_x: 11
 v1_y: 16
 
+# Use variables equalities/inequalities in the constraints 
+thoth local tests/json_files/cairo_0/cairo_test_symbolic_execution.json --symbolic -function __main__.test_symbolic_execution -constraint v4!=v6 -solve v0_x v1_y
+
+v0_x: 1
+
 # Replace a variable using the -variable flag 
 thoth local tests/json_files/cairo_0/cairo_test_symbolic_execution_3.json --symbolic -function __main__.test_symbolic_execution -constraint v13==0 v14==0 v15==0  -solve v0_f v1_u v2_z v3_z2 -variables v3_z2=26  
 v0_f: 102

--- a/README.md
+++ b/README.md
@@ -129,11 +129,17 @@ thoth local tests/json_files/cairo_0/cairo_test_symbolic_execution.json -a assig
 # Set variables with a custom value
 thoth local tests/json_files/cairo_test_symbolic_execution.json --symbolic -function __main__.test_symbolic_execution -variables v0_x=1 -constraint v4==0 v6==0 -solve v1_y
 
-# Solve the variables values with contraints 
+# Solve the variables values with constraints 
 thoth local tests/json_files/cairo_0/cairo_test_symbolic_execution.json --symbolic -function __main__.test_symbolic_execution -constraint v4==0 v6==0 -solve v0_x v1_y
 
 v0_x: 10
 v1_y: 15
+
+# Use inequalities in the constraints 
+thoth local tests/json_files/cairo_0/cairo_test_symbolic_execution.json --symbolic -function __main__.test_symbolic_execution -constraint v4!=0 v6!=0 -solve v0_x v1_y
+
+v0_x: 11
+v1_y: 16
 
 # Replace a variable using the -variable flag 
 thoth local tests/json_files/cairo_0/cairo_test_symbolic_execution_3.json --symbolic -function __main__.test_symbolic_execution -constraint v13==0 v14==0 v15==0  -solve v0_f v1_u v2_z v3_z2 -variables v3_z2=26  

--- a/sierra/objects/objects.py
+++ b/sierra/objects/objects.py
@@ -255,7 +255,6 @@ class SierraControlFlowGraph:
             if isinstance(statement, SierraConditionalBranch):
                 # Conditional branch with 2 edges (JNZ)
                 if statement.edge_2_offset is not None:
-
                     current_basic_block.edges.append(
                         Edge(
                             source=statement.offset,

--- a/sierra/thoth_sierra.py
+++ b/sierra/thoth_sierra.py
@@ -8,7 +8,6 @@ from sierra.decompiler.decompiler import SierraDecompiler
 
 
 def main() -> None:
-
     args = parse_arguments()
 
     # Show analyzers help

--- a/thoth/app/cfg/callgraph.py
+++ b/thoth/app/cfg/callgraph.py
@@ -48,7 +48,6 @@ class CallFlowGraph:
         ]
 
         for function in functions:
-
             # Default values
             shape = self.config["default"]["shape"]
             color = self.config["default"]["color"]

--- a/thoth/app/cfg/cfg.py
+++ b/thoth/app/cfg/cfg.py
@@ -236,7 +236,6 @@ class CFG:
 
         # Build the edges btw basicblocks
         for block in self.basicblocks:
-
             # Create all the basicblock nodes
             shape = "square"
             label_instruction = ""

--- a/thoth/app/decompiler/decompiler.py
+++ b/thoth/app/decompiler/decompiler.py
@@ -88,7 +88,6 @@ class Decompiler:
             source_code += self._handle_hint_decomp(instruction)
 
         if "ASSERT_EQ" in instruction.opcode:
-
             source_code += self._handle_assert_eq_decomp(instruction)
             if "REGULAR" not in instruction.apUpdate:
                 op = list(filter(None, re.split(r"(\d+)", instruction.apUpdate)))
@@ -142,7 +141,6 @@ class Decompiler:
         source_code = ""
 
         for function in self.functions:
-
             self.current_function = function
             self.tab_count = 0
             count = 0
@@ -215,7 +213,6 @@ class Decompiler:
 
             self.first_pass = False
             for block in function.cfg.basicblocks:
-
                 self.current_basic_block = block
                 self.block_new_variables = 0
                 instructions = block.instructions

--- a/thoth/app/disassembler/cairo_instruction.py
+++ b/thoth/app/disassembler/cairo_instruction.py
@@ -153,6 +153,7 @@ OPCODE_RET_BIT = 13
 OPCODE_ASSERT_EQ_BIT = 14
 # RESERVED_BIT = 15.
 
+
 # https://github.com/starkware-libs/cairo-lang/blob/4e233516f52477ad158bc81a86ec2760471c1b65/src/starkware/cairo/lang/compiler/encode.py#L131
 def decode_instruction(encoding: int, imm: Optional[int] = None) -> Instruction:
     """Given 1 or 2 integers representing an instruction, returns the Instruction.

--- a/thoth/app/disassembler/instruction.py
+++ b/thoth/app/disassembler/instruction.py
@@ -173,7 +173,6 @@ class Instruction:
                 )
         # dw statements
         elif self.hint is None and self.imm == "None":
-
             try:
                 dw_value = int(self.off3)
                 assembly += self.print_instruction(f"dw {dw_value}", color=utils.color.BLUE)

--- a/thoth/app/symbex/symbex.py
+++ b/thoth/app/symbex/symbex.py
@@ -171,7 +171,7 @@ class SymbolicExecution:
         Use the symbolic execution to solve a list of constraints
         """
         # Parse the variables and constraints defined with the CLI arguments
-        constraint_regexp = re.compile("(v[0-9]{1,4}(_[a-zA-Z0-9_]+)?)==([0-9]+)")
+        constraint_regexp = re.compile("(v[0-9]{1,4}(_[a-zA-Z0-9_]+)?)((==)|(!=))([0-9]+)")
         variable_value_regexp = re.compile("(v[0-9]{1,4}(_[a-zA-Z0-9_]+)?)=([0-9]+)")
         solve_regexp = re.compile("(v[0-9]{1,4}(_[a-zA-Z0-9_]+)?)")
 
@@ -226,13 +226,18 @@ class SymbolicExecution:
             # Load variables values defined in CLI into Z3
             for variable in variables_values_list:
                 variable_name = [v for v in self.z3_variables if str(v) == variable[0][0]][0]
-                self.solver.add(variable_name == int(variable[0][2]))
+                self.solver.add(variable_name == int(variable[0][4]))
 
             # Load constraints defined in CLI into Z3
             for constraint in constraints_list:
                 try:
                     variable_name = [v for v in self.z3_variables if str(v) == constraint[0][0]][0]
-                    self.solver.add(variable_name == int(constraint[0][2]))
+                    # Equality constraint
+                    if constraint[0][2] == "==":
+                        self.solver.add(variable_name == int(constraint[0][5]))
+                    # Inequality constraint
+                    else:
+                        self.solver.add(variable_name != int(constraint[0][5]))
                 except:
                     continue
 

--- a/thoth/app/symbex/symbex.py
+++ b/thoth/app/symbex/symbex.py
@@ -33,7 +33,6 @@ class SymbolicExecution:
         Assign variables value in the z3 solver
         """
         for variable in variables:
-
             if variable.value is None:
                 continue
             if variable.value.type == VariableValueType.FUNCTION_CALL:

--- a/thoth/thoth.py
+++ b/thoth/thoth.py
@@ -107,7 +107,6 @@ def main() -> int:
 
     # Symbolic execution
     if args.symbolic:
-
         # Mandatory arguments (function, solve, constraint)
         if args.function is None:
             print(


### PR DESCRIPTION
This PR Fixes #118.

It is now possible to use  inequalities for constraints in this way:
`-constraint v4!=0 v6!=0`

Or variable comparison constraints like this:
`-constraint v4==v6`