### PR TITLE
Dev/antonin

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ thoth local tests/json_files/cairo_0/cairo_array_sum.json --analyzers-help
 
 ## Use the symbolic execution 
 
+#### Using the command-line
+
 ``` python
 # List all assigned variables using the `assignations` analyzer or using the decompiler `-d`
 thoth local tests/json_files/cairo_0/cairo_test_symbolic_execution.json -a assignations
@@ -127,7 +129,7 @@ thoth local tests/json_files/cairo_0/cairo_test_symbolic_execution.json -a assig
 [+] 1 analyzer was run (1 detected)
 
 # Set variables with a custom value
-thoth local tests/json_files/cairo_test_symbolic_execution.json --symbolic -function __main__.test_symbolic_execution -variables v0_x=1 -constraint v4==0 v6==0 -solve v1_y
+thoth local tests/json_files/cairo_0/cairo_test_symbolic_execution.json --symbolic -function __main__.test_symbolic_execution -variables v0_x=1 -constraint v4==0 v6==0 -solve v1_y
 
 # Solve the variables values with constraints 
 thoth local tests/json_files/cairo_0/cairo_test_symbolic_execution.json --symbolic -function __main__.test_symbolic_execution -constraint v4==0 v6==0 -solve v0_x v1_y
@@ -188,6 +190,35 @@ v6_g: 103
 v7_l: 108
 v8_a: 97
 v9_b: 98
+```
+
+#### With a configuration file
+
+It is also possible to use symbolic execution with a YAML configuration file.
+
+An example with this `config.yaml` file:
+```yaml
+function: "__main__.test_symbolic_execution"
+constraints: 
+    - "v13>0"
+    - "v14>=0"
+    - "v15<=0"
+solves:
+   - "v0_f"
+   - "v1_u" 
+   - "v2_z"
+   - "v3_z2"
+variables:
+   - "v3_z2=26"
+```
+
+We can run this command:
+```python
+thoth local tests/json_files/cairo_0/cairo_test_symbolic_execution_3.json --symbolic -config ./config.yaml
+v0_f: 103
+v1_u: 117
+v2_z: 122
+v3_z2: 26
 ```
 
 ## Print the contract's data-flow graph (DFG)

--- a/thoth/app/arguments.py
+++ b/thoth/app/arguments.py
@@ -197,13 +197,15 @@ For a specific output format (pdf/svg/png):
         help="Print JSON with details of all instructions",
     )
 
+    symbex.add_argument("-config", type=argparse.FileType("r"), help="YAML Config file")
+
     symbex.add_argument("-assertions", action="store_true", help="", default=[])
 
-    symbex.add_argument("-constraint", nargs="+", help="", default=[])
+    symbex.add_argument("-constraints", nargs="+", help="", default=[])
 
     symbex.add_argument("-variables", nargs="+", help="", default=[])
 
-    symbex.add_argument("-solve", nargs="+", help="", default=[])
+    symbex.add_argument("-solves", nargs="+", help="", default=[])
 
     contract_subparser = parser.add_subparsers(
         help="Load a cairo contract compilation artifact from a file or from starknet",

--- a/thoth/app/symbex/symbex.py
+++ b/thoth/app/symbex/symbex.py
@@ -170,12 +170,12 @@ class SymbolicExecution:
         Use the symbolic execution to solve a list of constraints
         """
         # Parse the variables and constraints defined with the CLI arguments
-        variable_regexp = re.compile("v[0-9]{1,4}")
+        variable_regexp = re.compile("v\d{1,4}")
         constraint_regexp = re.compile(
-            "(v[0-9]{1,4}(_[a-zA-Z0-9_]+)?)((==)|(!=))(([0-9]+)|(v[0-9]{1,4}))"
+            "(v\d{1,4}(_\w+)?)((==)|(!=)|(>=)|(>)|(<=)|(<))((\d+)|(v\d{1,4}))"
         )
-        variable_value_regexp = re.compile("(v[0-9]{1,4}(_[a-zA-Z0-9_]+)?)=([0-9]+)")
-        solve_regexp = re.compile("(v[0-9]{1,4}(_[a-zA-Z0-9_]+)?)")
+        variable_value_regexp = re.compile("(v\d{1,4}(_\w+)?)=(\d+)")
+        solve_regexp = re.compile("(v\d{1,4}(_\w+)?)")
 
         # Constraints defined in the CLI arguments
         constraints_list = []
@@ -236,20 +236,32 @@ class SymbolicExecution:
                     variable_name = [v for v in self.z3_variables if str(v) == constraint[0][0]][0]
 
                     # Constraint with an integer
-                    if constraint[0][6]:
-                        right_side_expression = int(constraint[0][5])
+                    if constraint[0][10]:
+                        right_side_expression = int(constraint[0][10])
                     # Constraint with another variable
                     else:
                         right_side_expression = [
-                            v for v in self.z3_variables if str(v) == constraint[0][5]
+                            v for v in self.z3_variables if str(v) == constraint[0][11]
                         ][0]
 
                     # Equality constraint
                     if constraint[0][2] == "==":
                         self.solver.add(variable_name == right_side_expression)
                     # Inequality constraint
-                    else:
+                    elif constraint[0][2] == "!=":
                         self.solver.add(variable_name != right_side_expression)
+                    # Superior constraint
+                    elif constraint[0][2] == ">":
+                        self.solver.add(variable_name > right_side_expression)
+                    # Superior or equal constraint
+                    elif constraint[0][2] == ">=":
+                        self.solver.add(variable_name >= right_side_expression)
+                    # Inferior constraint
+                    elif constraint[0][2] == "<":
+                        self.solver.add(variable_name < right_side_expression)
+                    # Inferior or equal constraint
+                    elif constraint[0][2] == "<=":
+                        self.solver.add(variable_name <= right_side_expression)
                 except:
                     continue
 

--- a/thoth/app/utils.py
+++ b/thoth/app/utils.py
@@ -1,4 +1,5 @@
 import sys
+import yaml
 from typing import List
 
 
@@ -127,3 +128,20 @@ def value_to_string(val: int, prime: int) -> str:
         return repr_str
     except Exception:
         return repr_hex
+
+
+def load_symbex_yaml_config(yaml_file: str) -> dict:
+    """
+    Load a symbolic execution config from a YAML file
+    """
+
+    yaml_data = yaml.safe_load(yaml_file)
+
+    symbex_config = {
+        "function": yaml_data["function"],
+        "constraints": yaml_data["constraints"],
+        "variables": yaml_data["variables"],
+        "solves": yaml_data["solves"],
+    }
+
+    return symbex_config

--- a/thoth/thoth.py
+++ b/thoth/thoth.py
@@ -118,7 +118,6 @@ def main() -> int:
                     symbex_solves,
                 ) = load_symbex_yaml_config(args.config).values()
             except Exception:
-                print("Symbolic execution: Impossible to load the config from %s" % args.config)
                 return 1
         # Load the symbolic execution parameters from the command line
         else:


### PR DESCRIPTION
- Adds comparison operators `>`, `>=`, `<`, and `<=` for the symbolic execution constraints. 

```python
thoth local tests/json_files/cairo_0/cairo_test_symbolic_execution.json --symbolic -function __main__.test_symbolic_execution -constraint v4\>=0 v6\<=0 -solve v0_x v1_y

v0_x: 10
v1_y: 15
```


- Adds the possibility to use the symbolic execution with a *YAML* configuration file.

For example with this `config.yaml` file:
```yaml
function: "__main__.test_symbolic_execution"
constraints: 
    - "v13>0"
    - "v14>=0"
    - "v15<=0"
solves:
   - "v0_f"
   - "v1_u" 
   - "v2_z"
   - "v3_z2"
variables:
   - "v3_z2=26"
```

We can run this command:
```python
thoth local tests/json_files/cairo_0/cairo_test_symbolic_execution_3.json --symbolic -config ./config.yaml
v0_f: 103
v1_u: 117
v2_z: 122
v3_z2: 26
```