### PR TITLE
Include sierra-analyzer in the Thoth repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "contract-class-converter/cairo"]
 	path = contract-class-converter/cairo
 	url = https://github.com/starkware-libs/cairo.git
+[submodule "sierra-analyzer"]
+	path = sierra-analyzer
+	url = git@github.com:FuzzingLabs/sierra-analyzer.git

--- a/sierra/README.md
+++ b/sierra/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> *thoth-sierra* has been rewritten in Rust in a new version: [sierra-analyzer](https://github.com/FuzzingLabs/thoth/tree/master/sierra-analyzer). It contains all the features of *thoth-sierra* (CFG, Callgraph, decompiler, detectors) and is more maintainable and efficient. 
+
 ## Decompile the Sierra file
 
 ```python

--- a/thoth/app/disassembler/abi_parser.py
+++ b/thoth/app/disassembler/abi_parser.py
@@ -427,8 +427,8 @@ def parse_to_json(json_data: str, json_type: dict) -> dict:
             incr = 2
         key = str(offset)
         bytecodes_to_json[actual_function]["instruction"][key] = {}
-        bytecodes_to_json[actual_function]["instruction"][key][
-            hex(bytecode_data[offset])
-        ] = decode_to_json(str(decoded))
+        bytecodes_to_json[actual_function]["instruction"][key][hex(bytecode_data[offset])] = (
+            decode_to_json(str(decoded))
+        )
         offset += incr
     return bytecodes_to_json

--- a/thoth/app/disassembler/cairo_instruction.py
+++ b/thoth/app/disassembler/cairo_instruction.py
@@ -212,9 +212,11 @@ def decode_instruction(encoding: int, imm: Optional[int] = None) -> Instruction:
     res = {
         (1, 0): Instruction.Res.ADD,
         (0, 1): Instruction.Res.MUL,
-        (0, 0): Instruction.Res.UNCONSTRAINED
-        if pc_update is Instruction.PcUpdate.JNZ
-        else Instruction.Res.OP1,
+        (0, 0): (
+            Instruction.Res.UNCONSTRAINED
+            if pc_update is Instruction.PcUpdate.JNZ
+            else Instruction.Res.OP1
+        ),
     }[(flags >> RES_ADD_BIT) & 1, (flags >> RES_MUL_BIT) & 1]
 
     # JNZ opcode means res must be UNCONSTRAINED.

--- a/thoth/app/disassembler/disassembler.py
+++ b/thoth/app/disassembler/disassembler.py
@@ -119,9 +119,11 @@ class Disassembler:
                     ret,
                     decorators,
                     self.labels,
-                    entry_point=self.json[function]["data"]["entry_point"]
-                    if json_type != "get_code"
-                    else True,
+                    entry_point=(
+                        self.json[function]["data"]["entry_point"]
+                        if json_type != "get_code"
+                        else True
+                    ),
                     is_import=is_import,
                 )
             )

--- a/thoth/app/disassembler/function.py
+++ b/thoth/app/disassembler/function.py
@@ -139,11 +139,7 @@ class Function:
             prototype += (
                 " -> ("
                 if data_name == "ret" and data_content is not None
-                else "("
-                if data_name == "args"
-                else "{"
-                if data_name == "implicitargs"
-                else ""
+                else "(" if data_name == "args" else "{" if data_name == "implicitargs" else ""
             )
             if data_content is not None:
                 for idarg in data_content:
@@ -155,9 +151,7 @@ class Function:
             prototype += (
                 ")"
                 if (data_name == "args" or (data_name == "ret" and data_content is not None))
-                else "}"
-                if data_name == "implicitargs"
-                else ""
+                else "}" if data_name == "implicitargs" else ""
             )
         return prototype
 


### PR DESCRIPTION
`sierra-analyzer` will now be included in the `thoth` repo as a sub-module, and the `thoth-sierra` documentation has been modified with a reference to `sierra-analyzer`. 